### PR TITLE
Add mesh cache cleanup

### DIFF
--- a/Editor/StructureManagerWindow.cs
+++ b/Editor/StructureManagerWindow.cs
@@ -680,6 +680,9 @@ namespace Mayuns.DSB.Editor
                     MeshCacheUtility.PickFolder();
 
                 EditorGUILayout.EndHorizontal();
+
+                if (GUILayout.Button("Clean Cache"))
+                    MeshCacheUtility.CleanUnusedCache();
             }
 
             EditorGUILayout.Space(4);


### PR DESCRIPTION
## Summary
- add `CleanUnusedCache` in `MeshCacheUtility` to remove unused cached meshes
- expose cleanup button in `StructureManagerWindow` next to mesh cache settings

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845fd08b068832998f37e5b0218344f