### PR TITLE
Add health and mass settings

### DIFF
--- a/Editor/StructureBuildTool.cs
+++ b/Editor/StructureBuildTool.cs
@@ -660,6 +660,9 @@ namespace Mayuns.DSB.Editor
             wall.numColumns = design.columns;
             wall.numRows = design.rows;
             wall.wallGrid = new List<WallPiece>(new WallPiece[wall.numColumns * wall.numRows]);
+            wall.WallPieceMass = buildSettings.wallPieceMass;
+            wall.wallPieceHealth = buildSettings.wallPieceHealth;
+            wall.wallPieceWindowHealth = buildSettings.wallPieceWindowHealth;
 
             for (int row = 0; row < wall.numRows; row++)
             {
@@ -1010,6 +1013,7 @@ namespace Mayuns.DSB.Editor
                         buildSettings.memberLength,
                         buildSettings.memberThickness,
                         buildSettings.memberMass,
+                        buildSettings.memberPieceHealth,
                         buildSettings.memberSupportCapacity,
                         buildSettings.connectionSize
                         );
@@ -1029,6 +1033,7 @@ namespace Mayuns.DSB.Editor
                     float baseLength,
                     float thickness,
                     float memberMass,
+                    float memberPieceHealth,
                     float memberSupportCapacity,
                     float connectionThickness)
         {
@@ -1091,6 +1096,7 @@ namespace Mayuns.DSB.Editor
             newMem.thickness = thickness;
             newMem.length = baseLength;
             newMem.mass = memberMass;
+            newMem.memberPieceHealth = memberPieceHealth;
             newMem.supportCapacity = memberSupportCapacity;
             newMem.BuildMember();
 
@@ -1312,6 +1318,10 @@ namespace Mayuns.DSB.Editor
 
             // Add the WallManager script to the wall for functionality
             WallManager spawnedWall = Undo.AddComponent<WallManager>(wall);
+
+            spawnedWall.WallPieceMass = buildSettings.wallPieceMass;
+            spawnedWall.wallPieceHealth = buildSettings.wallPieceHealth;
+            spawnedWall.wallPieceWindowHealth = buildSettings.wallPieceWindowHealth;
 
             StructuralGroupManager structuralGroup = parent.GetComponent<StructuralGroupManager>();
             if (structuralGroup)

--- a/Editor/StructureManagerWindow.cs
+++ b/Editor/StructureManagerWindow.cs
@@ -570,6 +570,7 @@ namespace Mayuns.DSB.Editor
             buildSettings.memberLength = EditorGUILayout.FloatField("Member Length", buildSettings.memberLength);
             buildSettings.memberThickness = EditorGUILayout.FloatField("Member Thickness", buildSettings.memberThickness);
             buildSettings.memberMass = EditorGUILayout.FloatField("Member Mass", buildSettings.memberMass);
+            buildSettings.memberPieceHealth = EditorGUILayout.FloatField("Member Piece Health", buildSettings.memberPieceHealth);
             buildSettings.memberSupportCapacity = EditorGUILayout.FloatField("Member Support Capacity", buildSettings.memberSupportCapacity);
             buildSettings.memberMaterial = (Material)EditorGUILayout.ObjectField("Member Material", buildSettings.memberMaterial, typeof(Material), false);
             buildSettings.disableDirection = (DisableDirection)EditorGUILayout.EnumPopup("Disable Direction", buildSettings.disableDirection);
@@ -596,6 +597,9 @@ namespace Mayuns.DSB.Editor
             GUILayout.Label("Materials", EditorStyles.boldLabel);
             buildSettings.wallMaterial = (Material)EditorGUILayout.ObjectField("Wall Material", buildSettings.wallMaterial, typeof(Material), false);
             buildSettings.glassMaterial = (Material)EditorGUILayout.ObjectField("Wall Glass Material", buildSettings.glassMaterial, typeof(Material), false);
+            buildSettings.wallPieceMass = EditorGUILayout.FloatField("Wall Piece Mass", buildSettings.wallPieceMass);
+            buildSettings.wallPieceHealth = EditorGUILayout.FloatField("Wall Piece Health", buildSettings.wallPieceHealth);
+            buildSettings.wallPieceWindowHealth = EditorGUILayout.FloatField("Window Piece Health", buildSettings.wallPieceWindowHealth);
 
             EditorGUIUtility.labelWidth = originalLabelWidth;
         }

--- a/Runtime/ScriptableObjects/StructureBuildSettings.cs
+++ b/Runtime/ScriptableObjects/StructureBuildSettings.cs
@@ -14,6 +14,7 @@ namespace Mayuns.DSB
         public float memberLength = 5f;
         public float memberThickness = 0.25f;
         public float memberMass = 10f;
+        public float memberPieceHealth = 100f;
         public float memberSupportCapacity = 100f;
         public Material memberMaterial;
         public DisableDirection disableDirection;
@@ -33,5 +34,8 @@ namespace Mayuns.DSB
         public float wallThickness = .2f;
         public int wallColumnCellCount = 5;
         public int wallRowCellCount = 5;
+        public float wallPieceMass = 50f;
+        public float wallPieceHealth = 100f;
+        public float wallPieceWindowHealth = 1f;
     }
 }


### PR DESCRIPTION
## Summary
- expose new spawn parameters in `StructureBuildSettings`
- allow editing piece health and wall piece mass in `StructureManagerWindow`
- propagate these values when spawning members and walls
- keep wall design application consistent with new defaults

## Testing
- `ls`

------
https://chatgpt.com/codex/tasks/task_e_68461bfd2e90832985a282237c5bb61f