### PR TITLE
Add UV scaling controls

### DIFF
--- a/Editor/StructureBuildTool.cs
+++ b/Editor/StructureBuildTool.cs
@@ -801,6 +801,8 @@ namespace Mayuns.DSB.Editor
             wall.WallPieceMass = buildSettings.wallPieceMass;
             wall.wallPieceHealth = buildSettings.wallPieceHealth;
             wall.wallPieceWindowHealth = buildSettings.wallPieceWindowHealth;
+            wall.textureScaleX = buildSettings.wallTextureScaleX;
+            wall.textureScaleY = buildSettings.wallTextureScaleY;
 
             for (int row = 0; row < wall.numRows; row++)
             {
@@ -1235,6 +1237,8 @@ namespace Mayuns.DSB.Editor
             newMem.length = baseLength;
             newMem.mass = memberMass;
             newMem.memberPieceHealth = memberPieceHealth;
+            newMem.textureScaleX = buildSettings.memberTextureScaleX;
+            newMem.textureScaleY = buildSettings.memberTextureScaleY;
             newMem.supportCapacity = memberSupportCapacity;
             newMem.BuildMember();
 
@@ -1460,6 +1464,8 @@ namespace Mayuns.DSB.Editor
             spawnedWall.WallPieceMass = buildSettings.wallPieceMass;
             spawnedWall.wallPieceHealth = buildSettings.wallPieceHealth;
             spawnedWall.wallPieceWindowHealth = buildSettings.wallPieceWindowHealth;
+            spawnedWall.textureScaleX = buildSettings.wallTextureScaleX;
+            spawnedWall.textureScaleY = buildSettings.wallTextureScaleY;
 
             StructuralGroupManager structuralGroup = parent.GetComponent<StructuralGroupManager>();
             if (structuralGroup)

--- a/Editor/StructureManagerWindow.cs
+++ b/Editor/StructureManagerWindow.cs
@@ -584,6 +584,8 @@ namespace Mayuns.DSB.Editor
             buildSettings.memberThickness = EditorGUILayout.FloatField("Member Thickness", buildSettings.memberThickness);
             buildSettings.memberMass = EditorGUILayout.FloatField("Member Mass", buildSettings.memberMass);
             buildSettings.memberPieceHealth = EditorGUILayout.FloatField("Member Piece Health", buildSettings.memberPieceHealth);
+            buildSettings.memberTextureScaleX = EditorGUILayout.FloatField("Member Texture Scale X", buildSettings.memberTextureScaleX);
+            buildSettings.memberTextureScaleY = EditorGUILayout.FloatField("Member Texture Scale Y", buildSettings.memberTextureScaleY);
             buildSettings.memberSupportCapacity = EditorGUILayout.FloatField("Member Support Capacity", buildSettings.memberSupportCapacity);
             buildSettings.memberMaterial = (Material)EditorGUILayout.ObjectField("Member Material", buildSettings.memberMaterial, typeof(Material), false);
             buildSettings.disableDirection = (DisableDirection)EditorGUILayout.EnumPopup("Disable Direction", buildSettings.disableDirection);
@@ -613,6 +615,8 @@ namespace Mayuns.DSB.Editor
             buildSettings.wallPieceMass = EditorGUILayout.FloatField("Wall Piece Mass", buildSettings.wallPieceMass);
             buildSettings.wallPieceHealth = EditorGUILayout.FloatField("Wall Piece Health", buildSettings.wallPieceHealth);
             buildSettings.wallPieceWindowHealth = EditorGUILayout.FloatField("Window Piece Health", buildSettings.wallPieceWindowHealth);
+            buildSettings.wallTextureScaleX = EditorGUILayout.FloatField("Wall Texture Scale X", buildSettings.wallTextureScaleX);
+            buildSettings.wallTextureScaleY = EditorGUILayout.FloatField("Wall Texture Scale Y", buildSettings.wallTextureScaleY);
 
             EditorGUIUtility.labelWidth = originalLabelWidth;
         }

--- a/Runtime/ScriptableObjects/StructureBuildSettings.cs
+++ b/Runtime/ScriptableObjects/StructureBuildSettings.cs
@@ -15,6 +15,8 @@ namespace Mayuns.DSB
         public float memberThickness = 0.25f;
         public float memberMass = 10f;
         public float memberPieceHealth = 100f;
+        public float memberTextureScaleX = 1f;
+        public float memberTextureScaleY = 1f;
         public float memberSupportCapacity = 100f;
         public Material memberMaterial;
         public DisableDirection disableDirection;
@@ -37,5 +39,7 @@ namespace Mayuns.DSB
         public float wallPieceMass = 50f;
         public float wallPieceHealth = 100f;
         public float wallPieceWindowHealth = 1f;
+        public float wallTextureScaleX = 1f;
+        public float wallTextureScaleY = 1f;
     }
 }

--- a/Runtime/StructuralMember.cs
+++ b/Runtime/StructuralMember.cs
@@ -33,8 +33,10 @@ namespace Mayuns.DSB
 		[field: SerializeField, HideInInspector] private Vector3 worldMemberSize;
 		[field: SerializeField] public float mass = 10f;
 		[field: SerializeField] public float supportCapacity = 100f;
-		[field: SerializeField] public float accumulatedLoad = 0f;
-		[field: SerializeField] public float memberPieceHealth = 100f;
+                [field: SerializeField] public float accumulatedLoad = 0f;
+                [field: SerializeField] public float memberPieceHealth = 100f;
+                [field: SerializeField, HideInInspector] public float textureScaleX = 1f;
+                [field: SerializeField, HideInInspector] public float textureScaleY = 1f;
 
 #if UNITY_EDITOR
 		private void OnDrawGizmosSelected()
@@ -496,11 +498,13 @@ namespace Mayuns.DSB
 				else
 				{
 					/*──── SLOW PATH : procedural build ────*/
-					cube = VoxelBuildingUtility.CreateIrregularCube(
-						 cubeSize, worldCubePosition, 0, 0, z,
-						 originalMaterial, cubeSize, vertexOffsets,
-						 worldMemberSize, 1, 1, memberDivisionsCount,
-						 "StructuralMemberVoxel");
+                                        cube = VoxelBuildingUtility.CreateIrregularCube(
+                                                 cubeSize, worldCubePosition, 0, 0, z,
+                                                 originalMaterial, cubeSize, vertexOffsets,
+                                                 worldMemberSize, 1, 1,
+                                                 new Vector2(textureScaleX, textureScaleY),
+                                                 memberDivisionsCount,
+                                                 "StructuralMemberVoxel");
 
 					MeshFilter mf = cube.GetComponent<MeshFilter>();
 					if (mf && mf.sharedMesh)

--- a/Runtime/Utilities/VoxelBuildingUtility.cs
+++ b/Runtime/Utilities/VoxelBuildingUtility.cs
@@ -16,6 +16,7 @@ namespace Mayuns.DSB
                 Vector3 worldWallSize,
                 int numRows,
                 int numColumns,
+                Vector2 textureScale,
                 string objectName)
         {
             GameObject quad = new GameObject(objectName);
@@ -102,6 +103,7 @@ namespace Mayuns.DSB
                 WallPiece.TriangularCornerDesignation corner,
                 Vector3 worldWallSize,
                 int numRows, int numColumns,
+                Vector2 textureScale,
                 string objectName)
         {
             GameObject triangle = new GameObject(objectName);
@@ -335,6 +337,9 @@ namespace Mayuns.DSB
                 trianglesList.Add(sideStart + 2);
             }
 
+            for (int i = 0; i < uvsList.Count; i++)
+                uvsList[i] = Vector2.Scale(uvsList[i], textureScale);
+
             mesh.SetVertices(verticesList);
             mesh.SetTriangles(trianglesList, 0);
             mesh.SetNormals(normalsList);
@@ -353,7 +358,9 @@ namespace Mayuns.DSB
                 Vector3 cubeSize,
                 Vector3[,,] vertexOffsets,
                 Vector3 worldWallSize,
-                int numRows, int numColumns, int numZDepth,
+                int numRows, int numColumns,
+                Vector2 textureScale,
+                int numZDepth,
                 string objectName)
         {
             GameObject cube = new GameObject(objectName);
@@ -473,6 +480,9 @@ namespace Mayuns.DSB
             uvs[21] = UvRight(x + 1, y + 1, z);
             uvs[22] = UvRight(x + 1, y + 1, z + 1);
             uvs[23] = UvRight(x + 1, y, z + 1);
+
+            for (int i = 0; i < uvs.Length; i++)
+                uvs[i] = Vector2.Scale(uvs[i], textureScale);
 
 
             Vector2 UvFront(int vx, int vy, int vz)


### PR DESCRIPTION
## Summary
- add texture scale fields to `StructureBuildSettings`
- store UV scaling per member and wall
- pass texture scale to voxel builders
- expose scaling in editor windows and apply when building

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68465431642883299a0105b2528dcecd