### PR TITLE
Add destruction event hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-"# Destructible-Structure-Builder" 
+# Destructible-Structure-Builder
+
+## Event Hooks
+
+`MemberPiece` and `WallPiece` now expose `onDestroyed` events and `Destructible` exposes `onCrumble`. Attach particle or sound effects in the Unity inspector by assigning listeners to these events.

--- a/Runtime/Destructible.cs
+++ b/Runtime/Destructible.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 using static Mayuns.DSB.GibBuildingUtility;
+using UnityEngine.Events;
 
 namespace Mayuns.DSB
 {
@@ -8,6 +9,8 @@ namespace Mayuns.DSB
     {
         [HideInInspector] public DebrisData[] gibs;
         private GibManager gibManager;
+        [Header("Destruction Events")]
+        public UnityEvent onCrumble;
 
         void Awake()
         {
@@ -71,6 +74,8 @@ namespace Mayuns.DSB
                     gib.transform.SetParent(null);
                 }
             }
+
+            onCrumble?.Invoke();
 
             Destroy(gameObject);
         }

--- a/Runtime/MemberPiece.cs
+++ b/Runtime/MemberPiece.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using UnityEngine.Events;
 
 namespace Mayuns.DSB
 {
@@ -7,6 +8,8 @@ namespace Mayuns.DSB
         [HideInInspector] public bool isDestroyed = false;
         [HideInInspector] public StructuralMember member;
         public float accumulatedDamage = 0;
+        [Header("Destruction Events")]
+        public UnityEvent onDestroyed;
 
         public void DestroyMemberPiece()
         {
@@ -27,6 +30,8 @@ namespace Mayuns.DSB
             if (accumulatedDamage >= member.memberPieceHealth)
             {
                 isDestroyed = true;
+
+                onDestroyed?.Invoke();
 
                 if (member != null)
                 {

--- a/Runtime/WallPiece.cs
+++ b/Runtime/WallPiece.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using UnityEngine.Events;
 
 namespace Mayuns.DSB
 {
@@ -13,6 +14,8 @@ namespace Mayuns.DSB
         [HideInInspector] public bool isEdge = false;
         [HideInInspector] public bool isProxy = false;
         [HideInInspector] public float accumulatedDamage = 0;
+        [Header("Destruction Events")]
+        public UnityEvent onDestroyed;
         public enum TriangularCornerDesignation
         {
             None,
@@ -54,6 +57,8 @@ namespace Mayuns.DSB
         private void HandleDestruction()
         {
             isDestroyed = true;
+
+            onDestroyed?.Invoke();
 
             if (manager != null)
             {


### PR DESCRIPTION
## Summary
- expose `onDestroyed` UnityEvents on `MemberPiece` and `WallPiece`
- add `onCrumble` event to `Destructible`
- document new events

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848c95a32248329bab47d2a0944d273