### PR TITLE
Enable stress visualization in edit mode

### DIFF
--- a/Editor/StressVisualizerToolbar.cs
+++ b/Editor/StressVisualizerToolbar.cs
@@ -20,6 +20,13 @@ namespace Mayuns.DSB.Editor
             _enabled = !_enabled;
             StressVisualizerState.IsEnabled = _enabled;   // ‹— keep single source of truth
             Menu.SetChecked(kMenuPath, _enabled);
+
+            if (_enabled && !EditorApplication.isPlaying)
+            {
+                foreach (var mgr in Object.FindObjectsOfType<StructuralGroupManager>())
+                    mgr.CalculateLoadsForEditor();
+            }
+
             SceneView.RepaintAll();                      // ‹— instant feedback
         }
 

--- a/Editor/StructuralMemberStressGizmo.cs
+++ b/Editor/StructuralMemberStressGizmo.cs
@@ -14,8 +14,15 @@ namespace Mayuns.DSB.Editor
         private static void DrawStress(StructuralMember member, GizmoType gizmoType)
         {
             if (!StressVisualizerState.IsEnabled ||
-                member == null || member.isDestroyed || member.isSplit ||member.isGrouped)
+                member == null || member.isDestroyed || member.isSplit || member.isGrouped)
                 return;
+
+            if (!Application.isPlaying)
+            {
+                var mgr = member.structuralGroup ? member.structuralGroup : member.GetComponentInParent<StructuralGroupManager>();
+                if (mgr)
+                    mgr.CalculateLoadsForEditor();
+            }
 
             /*────────── Colour calculation (same as before) ──────────*/
             float stress =


### PR DESCRIPTION
## Summary
- recompute loads when toggling the stress visualizer
- recompute loads per structural member when drawing gizmos

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848e6f877808329bd139dd3c1138812