### PR TITLE
Member and wall piece values from manager

### DIFF
--- a/Editor/StructuralGroupManagerEditor.cs
+++ b/Editor/StructuralGroupManagerEditor.cs
@@ -30,10 +30,31 @@ namespace Mayuns.DSB.Editor
             }
 
             EditorGUI.BeginChangeCheck();
-            float newMass = EditorGUILayout.FloatField("Piece Mass", manager.pieceMass);
+            float newMemberMass = EditorGUILayout.FloatField("Member Piece Mass", manager.memberPieceMass);
             if (EditorGUI.EndChangeCheck())
             {
-                manager.ApplyPieceMass(newMass);
+                manager.ApplyMemberPieceMass(newMemberMass);
+            }
+
+            EditorGUI.BeginChangeCheck();
+            float newMemberHealth = EditorGUILayout.FloatField("Member Piece Health", manager.memberPieceHealth);
+            if (EditorGUI.EndChangeCheck())
+            {
+                manager.ApplyMemberPieceHealth(newMemberHealth);
+            }
+
+            EditorGUI.BeginChangeCheck();
+            float newWallMass = EditorGUILayout.FloatField("Wall Piece Mass", manager.wallPieceMass);
+            if (EditorGUI.EndChangeCheck())
+            {
+                manager.ApplyWallPieceMass(newWallMass);
+            }
+
+            EditorGUI.BeginChangeCheck();
+            float newWallHealth = EditorGUILayout.FloatField("Wall Piece Health", manager.wallPieceHealth);
+            if (EditorGUI.EndChangeCheck())
+            {
+                manager.ApplyWallPieceHealth(newWallHealth);
             }
 
             EditorGUI.BeginChangeCheck();

--- a/Editor/StructureBuildTool.cs
+++ b/Editor/StructureBuildTool.cs
@@ -315,6 +315,10 @@ namespace Mayuns.DSB.Editor
                 structuralGroup.minPropagationTime = buildSettings.minPropagationTime;
                 structuralGroup.maxPropagationTime = buildSettings.maxPropagationTime;
                 structuralGroup.buildSettings = buildSettings;
+                structuralGroup.memberPieceMass = buildSettings.memberMass;
+                structuralGroup.memberPieceHealth = buildSettings.memberPieceHealth;
+                structuralGroup.wallPieceMass = buildSettings.wallPieceMass;
+                structuralGroup.wallPieceHealth = buildSettings.wallPieceHealth;
                 structuralGroup.audioSource = structuralGroup.GetComponent<AudioSource>();
                 if (structuralGroup.audioSource == null)
                 {
@@ -809,8 +813,16 @@ namespace Mayuns.DSB.Editor
             wall.numColumns = design.columns;
             wall.numRows = design.rows;
             wall.wallGrid = new List<WallPiece>(new WallPiece[wall.numColumns * wall.numRows]);
-            wall.WallPieceMass = buildSettings.wallPieceMass;
-            wall.wallPieceHealth = buildSettings.wallPieceHealth;
+            if (wall.structuralGroup != null)
+            {
+                wall.WallPieceMass = wall.structuralGroup.wallPieceMass;
+                wall.wallPieceHealth = wall.structuralGroup.wallPieceHealth;
+            }
+            else
+            {
+                wall.WallPieceMass = buildSettings.wallPieceMass;
+                wall.wallPieceHealth = buildSettings.wallPieceHealth;
+            }
             wall.wallPieceWindowHealth = buildSettings.wallPieceWindowHealth;
             wall.textureScaleX = buildSettings.wallTextureScaleX;
             wall.textureScaleY = buildSettings.wallTextureScaleY;
@@ -1163,8 +1175,8 @@ namespace Mayuns.DSB.Editor
                         buildSettings.connectionMaterial,
                         buildSettings.memberLength,
                         buildSettings.memberThickness,
-                        buildSettings.memberMass,
-                        buildSettings.memberPieceHealth,
+                        connection.structuralGroup != null ? connection.structuralGroup.memberPieceMass : buildSettings.memberMass,
+                        connection.structuralGroup != null ? connection.structuralGroup.memberPieceHealth : buildSettings.memberPieceHealth,
                         buildSettings.memberSupportCapacity,
                         buildSettings.connectionSize
                         );
@@ -1472,8 +1484,8 @@ namespace Mayuns.DSB.Editor
             // Add the WallManager script to the wall for functionality
             WallManager spawnedWall = Undo.AddComponent<WallManager>(wall);
 
-            spawnedWall.WallPieceMass = buildSettings.wallPieceMass;
-            spawnedWall.wallPieceHealth = buildSettings.wallPieceHealth;
+            spawnedWall.WallPieceMass = structuralGroup != null ? structuralGroup.wallPieceMass : buildSettings.wallPieceMass;
+            spawnedWall.wallPieceHealth = structuralGroup != null ? structuralGroup.wallPieceHealth : buildSettings.wallPieceHealth;
             spawnedWall.wallPieceWindowHealth = buildSettings.wallPieceWindowHealth;
             spawnedWall.textureScaleX = buildSettings.wallTextureScaleX;
             spawnedWall.textureScaleY = buildSettings.wallTextureScaleY;

--- a/Editor/StructureManagerWindow.cs
+++ b/Editor/StructureManagerWindow.cs
@@ -594,8 +594,6 @@ namespace Mayuns.DSB.Editor
             GUILayout.Label("Structural Member Settings", EditorStyles.boldLabel);
             buildSettings.memberLength = EditorGUILayout.FloatField("Member Length", buildSettings.memberLength);
             buildSettings.memberThickness = EditorGUILayout.FloatField("Member Thickness", buildSettings.memberThickness);
-            buildSettings.memberMass = EditorGUILayout.FloatField("Member Mass", buildSettings.memberMass);
-            buildSettings.memberPieceHealth = EditorGUILayout.FloatField("Member Piece Health", buildSettings.memberPieceHealth);
             buildSettings.memberTextureScaleX = EditorGUILayout.FloatField("Member Texture Scale X", buildSettings.memberTextureScaleX);
             buildSettings.memberTextureScaleY = EditorGUILayout.FloatField("Member Texture Scale Y", buildSettings.memberTextureScaleY);
             buildSettings.memberSupportCapacity = EditorGUILayout.FloatField("Member Support Capacity", buildSettings.memberSupportCapacity);
@@ -624,8 +622,6 @@ namespace Mayuns.DSB.Editor
             GUILayout.Label("Materials", EditorStyles.boldLabel);
             buildSettings.wallMaterial = (Material)EditorGUILayout.ObjectField("Wall Material", buildSettings.wallMaterial, typeof(Material), false);
             buildSettings.glassMaterial = (Material)EditorGUILayout.ObjectField("Wall Glass Material", buildSettings.glassMaterial, typeof(Material), false);
-            buildSettings.wallPieceMass = EditorGUILayout.FloatField("Wall Piece Mass", buildSettings.wallPieceMass);
-            buildSettings.wallPieceHealth = EditorGUILayout.FloatField("Wall Piece Health", buildSettings.wallPieceHealth);
             buildSettings.wallPieceWindowHealth = EditorGUILayout.FloatField("Window Piece Health", buildSettings.wallPieceWindowHealth);
             buildSettings.wallTextureScaleX = EditorGUILayout.FloatField("Wall Texture Scale X", buildSettings.wallTextureScaleX);
             buildSettings.wallTextureScaleY = EditorGUILayout.FloatField("Wall Texture Scale Y", buildSettings.wallTextureScaleY);
@@ -643,6 +639,12 @@ namespace Mayuns.DSB.Editor
             EditorGUILayout.Space(10);
             GUILayout.Label("Structural Strength", EditorStyles.boldLabel);
             buildSettings.strengthModifier = EditorGUILayout.IntField("Member Support Capacity Modifier", buildSettings.strengthModifier);
+            EditorGUILayout.Space(10);
+            GUILayout.Label("Initial Piece Settings", EditorStyles.boldLabel);
+            buildSettings.memberMass = EditorGUILayout.FloatField("Member Piece Mass", buildSettings.memberMass);
+            buildSettings.memberPieceHealth = EditorGUILayout.FloatField("Member Piece Health", buildSettings.memberPieceHealth);
+            buildSettings.wallPieceMass = EditorGUILayout.FloatField("Wall Piece Mass", buildSettings.wallPieceMass);
+            buildSettings.wallPieceHealth = EditorGUILayout.FloatField("Wall Piece Health", buildSettings.wallPieceHealth);
             EditorGUILayout.Space(10);
             EditorGUILayout.LabelField("Stress Damage Propagation Timing", EditorStyles.boldLabel);
 

--- a/Runtime/StructuralGroupManager.cs
+++ b/Runtime/StructuralGroupManager.cs
@@ -13,7 +13,10 @@ namespace Mayuns.DSB
         public int strengthModifier;
         public float minPropagationTime = 0f;
         public float maxPropagationTime = 3f;
-        public float pieceMass = 10f;
+        public float memberPieceMass = 10f;
+        public float memberPieceHealth = 100f;
+        public float wallPieceMass = 50f;
+        public float wallPieceHealth = 100f;
         [System.Serializable]
         public class EffectInfo
         {
@@ -821,12 +824,12 @@ namespace Mayuns.DSB
             }
         }
 
-        public void ApplyPieceMass(float newMass)
+        public void ApplyMemberPieceMass(float newMass)
         {
-            if (Mathf.Approximately(pieceMass, 0f))
-                pieceMass = 1f;
+            if (Mathf.Approximately(memberPieceMass, 0f))
+                memberPieceMass = 1f;
 
-            float ratio = newMass / pieceMass;
+            float ratio = newMass / memberPieceMass;
 
             foreach (var member in structuralMembers)
             {
@@ -844,8 +847,58 @@ namespace Mayuns.DSB
                 EditorUtility.SetDirty(wall);
             }
 
-            Undo.RecordObject(this, "Change Piece Mass");
-            pieceMass = newMass;
+            Undo.RecordObject(this, "Change Member Piece Mass");
+            memberPieceMass = newMass;
+            EditorUtility.SetDirty(this);
+        }
+
+        public void ApplyWallPieceMass(float newMass)
+        {
+            if (Mathf.Approximately(wallPieceMass, 0f))
+                wallPieceMass = 1f;
+
+            float ratio = newMass / wallPieceMass;
+
+            foreach (var wall in walls)
+            {
+                if (wall == null) continue;
+                Undo.RecordObject(wall, "Change Wall Piece Mass");
+                wall.WallPieceMass *= ratio;
+                EditorUtility.SetDirty(wall);
+            }
+
+            Undo.RecordObject(this, "Change Wall Piece Mass");
+            wallPieceMass = newMass;
+            EditorUtility.SetDirty(this);
+        }
+
+        public void ApplyMemberPieceHealth(float newHealth)
+        {
+            foreach (var member in structuralMembers)
+            {
+                if (member == null) continue;
+                Undo.RecordObject(member, "Change Member Piece Health");
+                member.memberPieceHealth = newHealth;
+                EditorUtility.SetDirty(member);
+            }
+
+            Undo.RecordObject(this, "Change Member Piece Health");
+            memberPieceHealth = newHealth;
+            EditorUtility.SetDirty(this);
+        }
+
+        public void ApplyWallPieceHealth(float newHealth)
+        {
+            foreach (var wall in walls)
+            {
+                if (wall == null) continue;
+                Undo.RecordObject(wall, "Change Wall Piece Health");
+                wall.wallPieceHealth = newHealth;
+                EditorUtility.SetDirty(wall);
+            }
+
+            Undo.RecordObject(this, "Change Wall Piece Health");
+            wallPieceHealth = newHealth;
             EditorUtility.SetDirty(this);
         }
 


### PR DESCRIPTION
## Summary
- drive mass and health settings from `StructuralGroupManager`
- expose member and wall piece fields in manager inspector
- propagate manager settings when creating structures
- show piece settings only when creating a structure

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848f9f98ea08329a6b829d07bc5aadb