### PR TITLE
Add defaults for crumble sounds

### DIFF
--- a/Runtime/StructuralGroupManager.cs
+++ b/Runtime/StructuralGroupManager.cs
@@ -766,6 +766,22 @@ namespace Mayuns.DSB
                 "Large_Collapse_Default5"
             });
 
+            AddIfMissing(EffectType.MemberDestroyed, new[]
+            {
+                "Crumble_Default1",
+                "Crumble_Default2",
+                "Crumble_Default3",
+                "Crumble_Default4"
+            });
+
+            AddIfMissing(EffectType.WallDestroyed, new[]
+            {
+                "Crumble_Default1",
+                "Crumble_Default2",
+                "Crumble_Default3",
+                "Crumble_Default4"
+            });
+
             effects = effectList.ToArray();
         }
 


### PR DESCRIPTION
## Summary
- assign default crumble audio clips to MemberDestroyed and WallDestroyed effects

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6849032c593483299e264d4b5dc76dd1