### PR TITLE
Unify texture scaling for connections

### DIFF
--- a/Editor/StructureBuildTool.cs
+++ b/Editor/StructureBuildTool.cs
@@ -306,6 +306,9 @@ namespace Mayuns.DSB.Editor
                 connectionGO.transform.SetParent(newStructure.transform, true);
 
                 StructuralConnection connectionReference = connectionGO.AddComponent<StructuralConnection>();
+                connectionReference.textureScaleX = buildSettings.memberTextureScaleX;
+                connectionReference.textureScaleY = buildSettings.memberTextureScaleY;
+                connectionReference.BuildConnection();
 
                 if (buildSettings.memberMaterial != null)
                     connectionGO.GetComponent<MeshRenderer>().sharedMaterial = buildSettings.memberMaterial;
@@ -1287,6 +1290,9 @@ namespace Mayuns.DSB.Editor
                 Undo.AddComponent<BoxCollider>(connGO);
                 endConn = Undo.AddComponent<StructuralConnection>(connGO);
                 endConn.structuralGroup = connection.structuralGroup;
+                endConn.textureScaleX = buildSettings.memberTextureScaleX;
+                endConn.textureScaleY = buildSettings.memberTextureScaleY;
+                endConn.BuildConnection();
 
                 Undo.SetTransformParent(connGO.transform,
                                         connection.structuralGroup.transform,

--- a/Runtime/StructuralConnection.cs
+++ b/Runtime/StructuralConnection.cs
@@ -131,12 +131,22 @@ namespace Mayuns.DSB
 
     public class StructuralConnection : Destructible, IDamageable
     {
+        [HideInInspector] public float textureScaleX = 1f;
+        [HideInInspector] public float textureScaleY = 1f;
         [field: SerializeField, HideInInspector] MemberMap _members = new();
         [HideInInspector] public StructuralGroupManager structuralGroup;
         [HideInInspector] public bool isDestroyed;
         public float health = 100f;
 
-        void Start() => CreateAndStoreDebrisData(1, false);
+        void Start()
+        {
+            BuildConnection();
+            CreateAndStoreDebrisData(1, false);
+        }
+
+#if UNITY_EDITOR
+        void OnValidate() => BuildConnection();
+#endif
 
         /// <summary>
         /// Remove this connection when no members remain attached.
@@ -218,6 +228,21 @@ namespace Mayuns.DSB
         {
             _members[slot] = newMem;
             endConn._members[slot.Opposite()] = newMem;
+        }
+
+        public void BuildConnection()
+        {
+            var mf = GetComponent<MeshFilter>();
+            if (mf == null || mf.sharedMesh == null) return;
+
+            Mesh mesh = Instantiate(mf.sharedMesh);
+            Vector2[] uvs = mesh.uv;
+            Vector2 scale = new(textureScaleX, textureScaleY);
+            for (int i = 0; i < uvs.Length; i++)
+                uvs[i] = Vector2.Scale(uvs[i], scale);
+            mesh.uv = uvs;
+            mesh.RecalculateBounds();
+            mf.sharedMesh = mesh;
         }
     }
 }


### PR DESCRIPTION
## Summary
- keep per-connection texture scale parameters
- build connection meshes using the member texture scale
- apply member texture scale when creating connections in editor

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b7bf99cfc83298c53619e6956b8a1