### PR TITLE
Add documentation PDF

### DIFF
--- a/Documentation/manual.pdf
+++ b/Documentation/manual.pdf
@@ -1,0 +1,56 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 404 >>
+stream
+BT
+/F1 18 Tf
+50 750 Td
+(Destructible Structure Builder Manual) Tj
+ET
+BT
+/F1 18 Tf
+50 725 Td
+() Tj
+ET
+BT
+/F1 18 Tf
+50 700 Td
+(This package provides tools for creating destructible structures in Unity.) Tj
+ET
+BT
+/F1 18 Tf
+50 675 Td
+(It includes WallPiece, MemberPiece, and a StructuralGroupManager to manage) Tj
+ET
+BT
+/F1 18 Tf
+50 650 Td
+(destruction events, sound effects, and stress visualization.) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000000696 00000 n 
+trailer
+<< /Root 1 0 R /Size 6 >>
+startxref
+766
+%%EOF


### PR DESCRIPTION
## Summary
- create a `Documentation` folder
- add a minimal `manual.pdf` explaining basic features of the package

## Testing
- `strings Documentation/manual.pdf | head`

------
https://chatgpt.com/codex/tasks/task_e_684b89cbce74832981c2ba113e0703ce