### PR TITLE
Scale collapse particles dynamically

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 - **MemberStress** clips trigger when overloaded members are damaged over time.
 - **LargeCollapse** clips trigger when a detached group with more than four members is created.
+- Large collapse particle effects now scale with the detached group's size.
 - **WindowShatter** clips trigger when a window piece is destroyed.
 
 Audio clips are loaded from `Resources/SoundEffects` when no custom clips are assigned.

--- a/Runtime/StructuralGroupManager.cs
+++ b/Runtime/StructuralGroupManager.cs
@@ -669,8 +669,9 @@ namespace Mayuns.DSB
             {
                 float tVal = Mathf.InverseLerp(1f, 100f, structuralGroup.structuralMembersHash.Count);
                 float collapseVolume = Mathf.Lerp(0.1f, .8f, tVal);
+                float collapseScale = Mathf.Lerp(1f, 3f, tVal);
 
-                PlayLargeCollapseAt(groupGO.transform.position, collapseVolume);
+                PlayLargeCollapseAt(groupGO.transform.position, collapseVolume, collapseScale);
             }
         }
 
@@ -684,9 +685,9 @@ namespace Mayuns.DSB
             PlayEffects(EffectType.MemberStress, position);
         }
 
-        public void PlayLargeCollapseAt(Vector3 position, float volumeScale)
+        public void PlayLargeCollapseAt(Vector3 position, float volumeScale, float particleScale)
         {
-            PlayEffects(EffectType.LargeCollapse, position, volumeScale);
+            PlayEffects(EffectType.LargeCollapse, position, volumeScale, particleScale);
         }
 
         public void PlayWindowShatterAt(Vector3 position)
@@ -696,10 +697,15 @@ namespace Mayuns.DSB
 
         private void PlayEffects(EffectType type, Vector3 position)
         {
-            PlayEffects(type, position, .5f);
+            PlayEffects(type, position, .5f, 1f);
         }
 
         private void PlayEffects(EffectType type, Vector3 position, float volumeScale)
+        {
+            PlayEffects(type, position, volumeScale, 1f);
+        }
+
+        private void PlayEffects(EffectType type, Vector3 position, float volumeScale, float particleScale)
         {
             if (effects == null) return;
 
@@ -724,7 +730,7 @@ namespace Mayuns.DSB
                         {
                             var obj = Instantiate(prefab, position, Quaternion.identity);
                             if (type == EffectType.LargeCollapse)
-                                obj.transform.localScale *= (1f + volumeScale);
+                                obj.transform.localScale *= particleScale;
 
                             // destroy particle object once all systems have finished
                             var systems = obj.GetComponentsInChildren<ParticleSystem>();


### PR DESCRIPTION
## Summary
- scale large collapse particle effects by detached group size
- document scaling in README

## Testing
- `echo "No tests to run"`

------
https://chatgpt.com/codex/tasks/task_e_684b932623f483298a59ed506e97866a