### PR TITLE
Enable mesh persistence checks

### DIFF
--- a/Editor/StructureBuildTool.cs
+++ b/Editor/StructureBuildTool.cs
@@ -110,6 +110,7 @@ namespace Mayuns.DSB.Editor
             }
             ManagerWindow.RepaintIfOpen();
             SceneView.RepaintAll();
+            CheckMeshPersistenceForScene();
         }
 
         public static void SetWallEditSubMode(WallEditSubMode subMode)
@@ -601,7 +602,7 @@ namespace Mayuns.DSB.Editor
             wall.textureScaleY = buildSettings.wallTextureScaleY;
             wall.InstantUncombine();
             wall.RelinkWallGridReferences();
-            wall.BuildWall(wall.wallGrid, true, buildSettings, false);
+            wall.BuildWall(wall.wallGrid, true, buildSettings, true);
             EditorUtility.SetDirty(wall);
         }
 
@@ -734,7 +735,7 @@ namespace Mayuns.DSB.Editor
             wall.glassMaterial = buildSettings.glassMaterial;
             wall.wallMaterial = buildSettings.wallMaterial;
 
-            wall.BuildWall(wall.wallGrid, true, buildSettings, false);
+            wall.BuildWall(wall.wallGrid, true, buildSettings, true);
             EditorUtility.SetDirty(wall);
         }
 
@@ -768,7 +769,7 @@ namespace Mayuns.DSB.Editor
             wall.glassMaterial = buildSettings.glassMaterial;
             wall.wallMaterial = buildSettings.wallMaterial;
 
-            wall.BuildWall(wall.wallGrid, true, buildSettings, false);
+            wall.BuildWall(wall.wallGrid, true, buildSettings, true);
             EditorUtility.SetDirty(wall);
         }
 
@@ -799,7 +800,7 @@ namespace Mayuns.DSB.Editor
             wall.glassMaterial = buildSettings.glassMaterial;
             wall.wallMaterial = buildSettings.wallMaterial;
 
-            wall.BuildWall(wall.wallGrid, true, buildSettings, false);
+            wall.BuildWall(wall.wallGrid, true, buildSettings, true);
             EditorUtility.SetDirty(wall);
         }
 
@@ -876,7 +877,7 @@ namespace Mayuns.DSB.Editor
             wall.glassMaterial = buildSettings.glassMaterial;
             wall.wallMaterial = buildSettings.wallMaterial;
 
-            wall.BuildWall(wall.wallGrid, true, buildSettings, false);
+            wall.BuildWall(wall.wallGrid, true, buildSettings, true);
 
             EditorUtility.SetDirty(wall);
         }
@@ -925,7 +926,7 @@ namespace Mayuns.DSB.Editor
             wall.glassMaterial = buildSettings.glassMaterial;
             wall.wallMaterial = buildSettings.wallMaterial;
 
-            wall.BuildWall(wall.wallGrid, true, buildSettings, false);
+            wall.BuildWall(wall.wallGrid, true, buildSettings, true);
             EditorUtility.SetDirty(wall);
         }
 
@@ -1033,7 +1034,7 @@ namespace Mayuns.DSB.Editor
             // --- apply materials & rebuild mesh ---
             wall.wallMaterial = buildSettings.wallMaterial;
             wall.glassMaterial = buildSettings.glassMaterial;
-            wall.BuildWall(wall.wallGrid, true, buildSettings, false);
+            wall.BuildWall(wall.wallGrid, true, buildSettings, true);
 
             EditorUtility.SetDirty(wall);
             UnityEditor.SceneManagement.EditorSceneManager.MarkSceneDirty(wall.gameObject.scene);
@@ -1580,6 +1581,19 @@ namespace Mayuns.DSB.Editor
         static StructuralMember SlotToMember(StructuralConnection c, string slot)
         {
             return SlotLookup.FromString.TryGetValue(slot, out var s) ? c.Get(s) : null;
+        }
+
+        static void CheckMeshPersistenceForScene()
+        {
+            foreach (var wall in Object.FindObjectsByType<WallManager>(FindObjectsSortMode.None))
+            {
+                wall.EnsureMeshesPersisted();
+            }
+
+            foreach (var member in Object.FindObjectsByType<StructuralMember>(FindObjectsSortMode.None))
+            {
+                member.EnsureMeshesPersisted();
+            }
         }
 
     }

--- a/Runtime/StructuralMember.cs
+++ b/Runtime/StructuralMember.cs
@@ -658,6 +658,26 @@ namespace Mayuns.DSB
                                 }
                         }
                 }
+
+#if UNITY_EDITOR
+                public void EnsureMeshesPersisted()
+                {
+                        int fp = ComputeFingerprint();
+                        if (memberPieces != null)
+                        {
+                                for (int i = 0; i < memberPieces.Length; i++)
+                                {
+                                        GameObject go = memberPieces[i];
+                                        if (!go) continue;
+                                        var mf = go.GetComponent<MeshFilter>();
+                                        if (mf && mf.sharedMesh && string.IsNullOrEmpty(AssetDatabase.GetAssetPath(mf.sharedMesh)))
+                                        {
+                                                mf.sharedMesh = MeshCacheUtility.PersistPiece(mf.sharedMesh, fp, i);
+                                        }
+                                }
+                        }
+                }
+#endif
 #endif
 	}
 

--- a/Runtime/WallManager.cs
+++ b/Runtime/WallManager.cs
@@ -1223,9 +1223,41 @@ namespace Mayuns.DSB
 					Undo.RecordObject(this, "Assign Wall Proxy Piece");
 					wallGrid[idx] = proxy;
 				}
-			}
-		}
+                        }
+                }
+
+#if UNITY_EDITOR
+        public void EnsureMeshesPersisted()
+        {
+                int fp = ComputeFingerprint();
+
+                for (int i = 0; i < _chunks.Count; i++)
+                {
+                        var chunk = _chunks[i];
+                        if (chunk == null) continue;
+                        var mf = chunk.GetComponent<MeshFilter>();
+                        if (mf && mf.sharedMesh && string.IsNullOrEmpty(AssetDatabase.GetAssetPath(mf.sharedMesh)))
+                        {
+                                mf.sharedMesh = MeshCacheUtility.PersistChunk(mf.sharedMesh, fp, i);
+                        }
+                }
+
+                if (wallGrid != null)
+                {
+                        for (int i = 0; i < wallGrid.Count; i++)
+                        {
+                                var piece = wallGrid[i];
+                                if (piece == null || piece.isProxy) continue;
+                                var mf = piece.GetComponent<MeshFilter>();
+                                if (mf && mf.sharedMesh && string.IsNullOrEmpty(AssetDatabase.GetAssetPath(mf.sharedMesh)))
+                                {
+                                        mf.sharedMesh = MeshCacheUtility.PersistPiece(mf.sharedMesh, fp, i);
+                                }
+                        }
+                }
+        }
+#endif
 
 #endif
-	}
+        }
 }


### PR DESCRIPTION
## Summary
- ensure all wall edits persist meshes
- check mesh persistence whenever build mode changes
- add `EnsureMeshesPersisted` utility methods for walls and members

## Testing
- `git commit -m "Ensure persistent meshes and add checks"`

------
https://chatgpt.com/codex/tasks/task_e_684ba98f6d5c83298f38ecbfedb631d1